### PR TITLE
Adjust logic for expanding compute instance

### DIFF
--- a/lib/sfn-serverspec/validator.rb
+++ b/lib/sfn-serverspec/validator.rb
@@ -164,8 +164,8 @@ module Sfn
         resource.logical_id == name
       end
 
-      if compute_resource.within?(:compute, :server)
-        [compute_resource.instance.expand]
+      if compute_resource.within?(:compute, :servers)
+        [compute_resource.expand]
       else
         compute_resource.expand.servers.map(&:expand)
       end


### PR DESCRIPTION
Leading up to initial release I was focused on expanding autoscaling groups and apparently didn't test single compute instance resources. This change made things work for the example template in the hw-labs/sparkleformation-workshops repository.
