### PR TITLE
Add `sfn serverspec` command for on-demand stack validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased changes
+* Use inherited bogo-ui instance for log messages
+* Fix incorrect scoping of methods on Sfn::Callback instead of Sfn::Callback::ServerspecValidator
+* Add sfn command for running on-demand validation of existing stack
 
 # v0.1.2
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,51 @@ The following configuration options specified at the resource level will overrid
 * `ssh_key_paths`
 * `ssh_key_passphrase`
 
+### On-demand validation
+
+Provided that you are using Bundler, this callback also adds a `serverspec` command to sfn, enabling on-demand validation of a running stack. You'll want to configure sfn-serverspec thusly:
+
+```ruby
+gem 'sfn-serverspec', :require => 'sfn-serverspec'
+```
+
+The `serverspec` command requires both a stack name and a template to use as the source of Serverspec configuration. The template may be provided via command line flag or interactive file path prompt:
+
+```
+$ bundle exec sfn serverspec example-stack -f sparkleformation/example.rb
+[Sfn]: Callback template serverspec_validator: starting
+[Sfn]: Callback template serverspec_validator: complete
+[Sfn]: Serverspec validating stack example-stack with template sparkleformation/example.rb:
+[Sfn]: Callback after_serverspec serverspec_validator: starting
+[Sfn]: Serverspec validating i-55836892 (10.101.100.15)
+
+base
+Port "22"
+should be listening
+
+hello world
+displays a custom message on the index page
+Port "80"
+should be listening
+
+Finished in 2.92 seconds (files took 10.49 seconds to load)
+3 examples, 0 failures
+
+[Sfn]: Serverspec validating i-52836895 (10.101.100.19)
+
+Port "22"
+should be listening
+
+hello world
+displays a custom message on the index page
+Port "80"
+should be listening
+
+Finished in 0.35415 seconds (files took 13.41 seconds to load)
+3 examples, 0 failures
+
+[Sfn]: Callback after_serverspec serverspec_validator: complete
+```
 
 ## Caveats
 
@@ -71,7 +116,7 @@ Providing `serverspec` configuration on compute resources works in a manner simi
 
 As of this writing, the callback only processes Serverspec configuration on `AWS::AutoScaling::AutoScalingGroup` and `AWS::EC2::Instance` resources.
 
-Non-compute resources with `serverspec` configuration will not be processed by this callback, and will probably cause a validation error when trying to validate or create a stack from the template.
+Non-compute resources with `serverspec` configuration will not be processed by this callback, and will probably yield a validation error when trying to validate or create a stack from the template.
 
 ## Info
 

--- a/lib/sfn-serverspec.rb
+++ b/lib/sfn-serverspec.rb
@@ -1,2 +1,4 @@
 require 'sfn-serverspec/version'
 require 'sfn-serverspec/validator'
+require 'sfn-serverspec/command/serverspec'
+require 'sfn-serverspec/config/serverspec'

--- a/lib/sfn-serverspec/command/serverspec.rb
+++ b/lib/sfn-serverspec/command/serverspec.rb
@@ -1,0 +1,29 @@
+require 'sparkle_formation'
+require 'sfn'
+require 'sfn-serverspec/validator'
+
+module Sfn
+  class Command
+    # Validate command
+    class Serverspec < Command
+      include Sfn::CommandModule::Base
+      include Sfn::CommandModule::Template
+      include Sfn::CommandModule::Stack
+
+      def execute!
+        name_required!
+        stack_name = name_args.last
+        root_stack = stack(stack_name)
+
+        print_only_original = config[:print_only]
+        config[:print_only] = true
+        load_template_file
+        ui.info "#{ui.color("Serverspec validation (#{provider.connection.provider}): ", :bold)} #{config[:file].sub(Dir.pwd, '').sub(%r{^/}, '')}" # rubocop:disable LineLength
+        config[:print_only] = print_only_original
+        api_action!(api_stack: root_stack) do
+          ui.info "Serverspec validating stack #{ui.color(root_stack.name, :bold)}:"
+        end
+      end
+    end
+  end
+end

--- a/lib/sfn-serverspec/command/serverspec.rb
+++ b/lib/sfn-serverspec/command/serverspec.rb
@@ -18,10 +18,9 @@ module Sfn
         print_only_original = config[:print_only]
         config[:print_only] = true
         load_template_file
-        ui.info "#{ui.color("Serverspec validation (#{provider.connection.provider}): ", :bold)} #{config[:file].sub(Dir.pwd, '').sub(%r{^/}, '')}" # rubocop:disable LineLength
         config[:print_only] = print_only_original
         api_action!(api_stack: root_stack) do
-          ui.info "Serverspec validating stack #{ui.color(root_stack.name, :bold)}:"
+          ui.info "Serverspec validating stack #{ui.color(root_stack.name, :bold)} with template #{config[:file].sub(Dir.pwd, '').sub(%r{^/}, '')}:" # rubocop:disable LineLength
         end
       end
     end

--- a/lib/sfn-serverspec/config/serverspec.rb
+++ b/lib/sfn-serverspec/config/serverspec.rb
@@ -1,0 +1,9 @@
+require 'sfn'
+
+module Sfn
+  class Config
+    # Serverspec command configuration
+    class Serverspec < Validate
+    end
+  end
+end

--- a/lib/sfn-serverspec/validator.rb
+++ b/lib/sfn-serverspec/validator.rb
@@ -24,7 +24,6 @@ module Sfn
       end
 
       def after_create(*args)
-
         policies.each do |resource, r_config|
           resource_config = r_config.dump!.to_smash(:snake)
 

--- a/lib/sfn-serverspec/validator.rb
+++ b/lib/sfn-serverspec/validator.rb
@@ -24,10 +24,6 @@ module Sfn
       end
 
       def after_create(*args)
-        log = Logger.new(STDOUT)
-        log.level = Logger.const_get(
-          config.fetch(:sfn_serverspec, :log_level, :info).to_s.upcase
-        )
 
         policies.each do |resource, r_config|
           resource_config = r_config.dump!.to_smash(:snake)
@@ -92,9 +88,9 @@ module Sfn
 
               spec_patterns = global_specs + resource_specs
 
-              log.debug "spec loading patterns: #{spec_patterns.inspect}"
-              log.debug "using SSH proxy commmand #{ssh_proxy_command}" unless ssh_proxy_command.nil?
-              log.info "running specs against #{target_host}"
+              ui.debug "spec loading patterns: #{spec_patterns.inspect}"
+              ui.debug "using SSH proxy commmand #{ssh_proxy_command}" unless ssh_proxy_command.nil?
+              ui.info "Serverspec validating #{instance.id} (#{target_host})"
 
               Specinfra.configuration.backend :ssh
               Specinfra.configuration.request_pty true
@@ -113,12 +109,12 @@ module Sfn
 
               unless ssh_proxy_command.nil?
                 connection_options[:proxy] = Net::SSH::Proxy::Command.new(ssh_proxy_command)
-                log.debug "using ssh proxy command: #{ssh_proxy_command}"
+                ui.debug "using ssh proxy command: #{ssh_proxy_command}"
               end
 
               unless ssh_key_paths.empty?
                 connection_options[:keys] = ssh_key_paths
-                log.debug "using ssh key paths #{connection_options[:keys]} exclusively"
+                ui.debug "using ssh key paths #{connection_options[:keys]} exclusively"
               end
 
               unless ssh_key_passphrase.nil?
@@ -130,7 +126,7 @@ module Sfn
               RSpec::Core::Runner.run(spec_patterns.map { |p| Dir.glob(p) })
 
             rescue => e
-              log.error "Something unexpected happened when running rspec: #{e.inspect}"
+              ui.error "Something unexpected happened when running rspec: #{e.inspect}"
             end
           end
         end

--- a/sfn-serverspec.gemspec
+++ b/sfn-serverspec.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'serverspec', '~> 2.24'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop', '~> 0.35.0'
+  s.add_development_dependency 'pry'
   s.files = Dir['{lib,bin,docs}/**/*'] + %w(sfn-serverspec.gemspec README.md CHANGELOG.md LICENSE)
 end


### PR DESCRIPTION
New `serverspec` command allows specs to be run against an existing stack instead of just after stack create. For now, this new command requires Bundler to work. See readme for details.
