### PR TITLE
Updating gemspec dependencies to require sfn 3.0

### DIFF
--- a/sfn-serverspec.gemspec
+++ b/sfn-serverspec.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = 'Executes Serverspec assertions against stack compute resources'
   s.license = 'Apache-2.0'
   s.require_path = 'lib'
-  s.add_runtime_dependency 'sfn', '>= 1.0', '< 4.0'
+  s.add_runtime_dependency 'sfn', '>= 3.0', '< 4.0'
   s.add_runtime_dependency 'serverspec', '~> 2.24'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop', '~> 0.35.0'


### PR DESCRIPTION
At some point in the 2.x releases it seems that our template callback
became broken, causing template validation failures and `--print-only`
output that does not reflect the final scrubbed template.

Pinning our dependencies to >= 3.0, < 4.0 should resolve this issue,
but is also a breaking change which merits a major version number change
in the next release.
